### PR TITLE
Change to mongo driver to make is easier to log timing information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@ driver developers who would rather use Maven than Ant as their build tool.
     <artifactId>mongo-java-driver</artifactId>
     <packaging>bundle</packaging>
     <name>MongoDB Java Driver</name>
-    <version>2.13.3</version>
+    <version>2.13.3-onshape</version>
     <description>The MongoDB Java driver</description>
     <url>http://www.mongodb.org</url>
 


### PR DESCRIPTION
Driver changes to log timing info for various calls. Can be activated with one of the following:

a.) Configure logger com.mongodb.TRACE with info level and set -DDB.TRACE=true
b.) Configure logger com.mongodb.TRACE with trace level

@jrrbelmont @jgdef 
